### PR TITLE
Shimmer fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 v2/v2.xcworkspace/xcuserdata/davidweissler.xcuserdatad/UserInterfaceState.xcuserstate
+v2/v2.xcworkspace/xcuserdata/davidweissler.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+v2/v2.xcworkspace/xcuserdata/davidweissler.xcuserdatad/UserInterfaceState.xcuserstate

--- a/v2/Pods/AFNetworking/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/v2/Pods/AFNetworking/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -155,14 +155,12 @@ static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notificat
 
 - (void)networkRequestDidStart:(NSNotification *)notification {
     if ([AFNetworkRequestFromNotification(notification) URL]) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"setShimmer" object:nil];
         [self incrementActivityCount];
     }
 }
 
 - (void)networkRequestDidFinish:(NSNotification *)notification {
     if ([AFNetworkRequestFromNotification(notification) URL]) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"setShimmer" object:nil];
         [self decrementActivityCount];
     }
 }

--- a/v2/v2/HomeViewController.m
+++ b/v2/v2/HomeViewController.m
@@ -30,6 +30,10 @@
 
 @implementation HomeViewController
 
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     

--- a/v2/v2/HomeViewController.m
+++ b/v2/v2/HomeViewController.m
@@ -245,24 +245,24 @@
     self.shimmeringView.contentView = self.voicesLabel;
     self.shimmeringView.shimmering = NO;
     
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingOperationDidStartNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingOperationDidFinishNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingTaskDidResumeNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingTaskDidSuspendNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingTaskDidCompleteNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmerOn) name:AFNetworkingOperationDidStartNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmerOff) name:AFNetworkingOperationDidFinishNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmerOn) name:AFNetworkingTaskDidResumeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmerOff) name:AFNetworkingTaskDidSuspendNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmerOff) name:AFNetworkingTaskDidCompleteNotification object:nil];
 }
 
 - (void)viewDidLayoutSubviews {
     //NSLog(@"My view's frame is: %@", NSStringFromCGRect(self.voicesLabel.frame));
 }
 
-- (void)toggleShimmer {
-    if (self.shimmeringView.shimmering) {
-        self.shimmeringView.shimmering = NO;
-    }
-    else {
-        self.shimmeringView.shimmering = YES;
-    }
+- (void)toggleShimmerOn {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self.shimmeringView selector:@selector(setShimmering:) object:@NO];
+    self.shimmeringView.shimmering = YES;
+}
+
+- (void)toggleShimmerOff {
+    [self.shimmeringView performSelector:@selector(setShimmering:) withObject:@NO afterDelay:2.0];
 }
 
 - (void)presentEmailViewController {
@@ -299,4 +299,5 @@
     }
     [self dismissViewControllerAnimated:YES completion:nil];
 }
+
 @end

--- a/v2/v2/HomeViewController.m
+++ b/v2/v2/HomeViewController.m
@@ -13,7 +13,7 @@
 #import "FBShimmeringView.h"
 #import "FBShimmeringLayer.h"
 
-@interface HomeViewController () 
+@interface HomeViewController ()
 @property (weak, nonatomic) IBOutlet UILabel *legislatureLevel;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *legislatureLevelTrailingConstraint;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *legislatureLevelLeadingConstraint;
@@ -65,7 +65,7 @@
 
 - (void)prepareSearchBar {
     self.searchBar.delegate = self;
-        
+    
     // ROUND THE BOX
     self.searchView.layer.cornerRadius = 5;
     self.searchView.clipsToBounds = YES;
@@ -172,7 +172,7 @@
     self.searchBarTopConstraint = [NSLayoutConstraint constraintWithItem:self.searchBar attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.searchView attribute:NSLayoutAttributeTop multiplier:1.0 constant:0];
     self.searchBarBottomConstraint = [NSLayoutConstraint constraintWithItem:self.searchBar attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.searchView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0];
     [self.view addConstraints:@[self.searchBarLeadingConstraint, self.searchBarTrailingConstraint, self.searchBarTopConstraint, self.searchBarBottomConstraint]];
-
+    
     self.searchBar.showsCancelButton = YES;
     self.isSearchBarOpen = YES;
     [self.searchBar becomeFirstResponder];
@@ -196,7 +196,7 @@
     
     // ADD LABEL CONSTRAINTS
     [self.view addConstraints:@[self.legislatureLevelLeadingConstraint, self.legislatureLevelTrailingConstraint]];
-
+    
     self.isSearchBarOpen = NO;
     [self.searchBar resignFirstResponder];
     [UIView animateWithDuration:0.25
@@ -245,10 +245,11 @@
     self.shimmeringView.contentView = self.voicesLabel;
     self.shimmeringView.shimmering = NO;
     
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(toggleShimmer)
-                                                 name:@"setShimmer"
-                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingOperationDidStartNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingOperationDidFinishNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingTaskDidResumeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingTaskDidSuspendNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleShimmer) name:AFNetworkingTaskDidCompleteNotification object:nil];
 }
 
 - (void)viewDidLayoutSubviews {
@@ -265,7 +266,6 @@
 }
 
 - (void)presentEmailViewController {
-
     MFMailComposeViewController *mailViewController = [[MFMailComposeViewController alloc] init];
     if ([MFMailComposeViewController canSendMail]) {
         mailViewController.mailComposeDelegate = self;

--- a/v2/v2/HomeViewController.m
+++ b/v2/v2/HomeViewController.m
@@ -157,7 +157,6 @@
     [searchBar setShowsCancelButton:NO animated:YES];
 }
 
-
 - (IBAction)openSearchBarButtonDidPress:(id)sender {
     [self showSearchBar];
 }
@@ -222,8 +221,7 @@
     CGSize requiredSize = [self.legislatureLevel sizeThatFits:maximumLabelSize];
     CGRect labelFrame = self.legislatureLevel.frame;
     labelFrame.size.width = requiredSize.width;
-    
-    
+
     self.legislatureLevel.frame = labelFrame;
     [UIView animateWithDuration:.15
                      animations:^{

--- a/v2/v2/HomeViewController.m
+++ b/v2/v2/HomeViewController.m
@@ -242,7 +242,7 @@
     self.shimmeringView.shimmering = NO;
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(setShimmer)
+                                             selector:@selector(toggleShimmer)
                                                  name:@"setShimmer"
                                                object:nil];
 }
@@ -251,7 +251,7 @@
     //NSLog(@"My view's frame is: %@", NSStringFromCGRect(self.voicesLabel.frame));
 }
 
-- (void)setShimmer {
+- (void)toggleShimmer {
     if (self.shimmeringView.shimmering) {
         self.shimmeringView.shimmering = NO;
     }


### PR DESCRIPTION
1. Remove custom code from AFNetworking (you would lose if you run pod install again).
2. Toggle shimmer based on AFNetworking notification of when a task starts/completes.
3. Add 2 second delay in turning the shimmer off for more visibility.
4. Random white space.
