### PR TITLE
372 federal emails hosted in firebase now

### DIFF
--- a/Voices/AppDelegate.m
+++ b/Voices/AppDelegate.m
@@ -43,6 +43,7 @@
     [self setCache];
     [self enableFeedbackAndReporting];
     [self unzipNYCDataSet];
+    [self getRepContactForms];
     [self excludeGeoJSONFromCloudBackup];
     [FIRApp configure];
     [GMSPlacesClient provideAPIKey:kAutocomplete];
@@ -269,7 +270,6 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     
     if ([[NSUserDefaults standardUserDefaults]objectForKey:kCityCouncilZip]) {
         [RepsManager sharedInstance].nycDistricts = [[[NSUserDefaults standardUserDefaults]objectForKey:kCityCouncilZip]valueForKey:@"features"];
-        
     }
     else {
         // Get the file path for the zip
@@ -328,6 +328,14 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
             [window removeConstraints:window.constraints];
         }
     }
+}
+
+-(void)getRepContactForms {
+    [[RepsManager sharedInstance]getRepContactFormsWithCompletion:^{
+        [[NSNotificationCenter defaultCenter]postNotificationName:@"reloadData" object:nil];
+    } onError:^ (NSError *error) {
+        NSLog(@"%@", [error localizedDescription]);
+    }];
 }
 
 @end

--- a/Voices/RepTableViewCell.h
+++ b/Voices/RepTableViewCell.h
@@ -10,6 +10,7 @@
 
 @interface RepTableViewCell : UITableViewCell
 
-- (void)initWithRep:(id)rep;
+@property(nonatomic)NSDictionary *repsContactForms;
+- (void)initWithRep:(id)rep andRepsContactForms:(NSDictionary *)repsContactForms;
 
 @end

--- a/Voices/RepTableViewCell.m
+++ b/Voices/RepTableViewCell.m
@@ -45,13 +45,14 @@
     [self registerCallStateNotification];
 }
 
-- (void)initWithRep:(id)rep {
+- (void)initWithRep:(id)rep andRepsContactForms:(NSDictionary *)repsContactForms {
     self.representative = rep;
     NSString *title = self.representative.shortTitle ? self.representative.shortTitle : self.representative.title;
     self.name.text = [NSString stringWithFormat:@"%@ %@ %@", title, self.representative.firstName, self.representative.lastName];
     self.tweetButton.tintColor = [UIColor voicesOrange];
     self.emailButton.tintColor = [UIColor voicesOrange];
     self.callButton.tintColor = [UIColor voicesOrange];
+    self.repsContactForms = repsContactForms;
     [self setupImage];
 }
 
@@ -127,9 +128,8 @@
 
 - (IBAction)emailButtonDidPress:(id)sender {
     if (self.representative.bioguide.length > 0) {
-        NSString *filePath = [[NSBundle mainBundle] pathForResource:kRepContactFormsJSON ofType:@"json"];
-        NSData *contactFormsJSON = [NSData dataWithContentsOfFile:filePath options:NSDataReadingUncached error:nil];
-        NSDictionary *contactFormsDict = [NSJSONSerialization JSONObjectWithData:contactFormsJSON options:NSJSONReadingAllowFragments error:nil];
+        
+        NSDictionary *contactFormsDict = self.repsContactForms;
         
         NSString *contactFormURLString = [contactFormsDict valueForKey:self.representative.bioguide];
         if (contactFormURLString.length == 0) {

--- a/Voices/RepsCollectionViewCell.m
+++ b/Voices/RepsCollectionViewCell.m
@@ -19,6 +19,7 @@
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (strong, nonatomic) UIRefreshControl *refreshControl;
 
+
 @end
 
 @implementation RepsCollectionViewCell
@@ -48,6 +49,7 @@
     self.emptyRepTableViewCell = [[EmptyRepTableViewCell alloc]init];
 }
 
+
 #pragma mark - UITableView Delegate Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
@@ -68,7 +70,7 @@
         
         cell = [tableView dequeueReusableCellWithIdentifier:kRepTableViewCell];
         
-        [cell initWithRep:self.tableViewDataSource[indexPath.row]];
+        [cell initWithRep:self.tableViewDataSource[indexPath.row] andRepsContactForms:[[RepsManager sharedInstance]repsContactForms]];
     }
     else {
         UITableViewCell *emptyStateCell = [[UITableViewCell alloc]init];

--- a/Voices/RepsManager.h
+++ b/Voices/RepsManager.h
@@ -12,11 +12,12 @@
 
 +(RepsManager *) sharedInstance;
 - (NSArray *)fetchRepsForIndex:(NSInteger)index;
-- (void)createFederalRepresentativesFromLocation:(CLLocation*)location WithCompletion:(void(^)(void))successBlock
-                                         onError:(void(^)(NSError *error))errorBlock;
+- (void)createFederalRepresentativesFromLocation:(CLLocation*)location WithCompletion:(void(^)(void))successBlock onError:(void(^)(NSError *error))errorBlock;
+-(void)getRepContactFormsWithCompletion:(void (^)(void))successBlock onError:(void (^)(NSError *))errorBlock;
 -(void)createStateRepresentativesFromLocation:(CLLocation *)location WithCompletion:(void (^)(void))successBlock onError:(void (^)(NSError *))errorBlock;
 - (void)createNYCRepsFromLocation:(CLLocation *)location;
 @property (strong, nonatomic) NSArray *nycDistricts;
+@property (strong, nonatomic) NSDictionary *repsContactForms;
 @property (strong, nonatomic) NSMutableArray *localReps;
 @property BOOL isLocalRepsAvailable;
 

--- a/Voices/RepsManager.m
+++ b/Voices/RepsManager.m
@@ -245,4 +245,14 @@
     return billDeBlasio;
 }
 
+-(void)getRepContactFormsWithCompletion:(void (^)(void))successBlock onError:(void (^)(NSError *))errorBlock {
+    [[RepsNetworkManager sharedInstance]getRepContactFormsWithCompletion:^(NSDictionary *results) {
+     if (successBlock) {
+          self.repsContactForms = results;
+     }
+    } onError:^(NSError *error) {
+        errorBlock(error);
+    }];
+}
+
 @end

--- a/Voices/RepsNetworkManager.h
+++ b/Voices/RepsNetworkManager.h
@@ -16,8 +16,8 @@
 +(RepsNetworkManager *) sharedInstance;
 - (void)getFederalRepresentativesFromLocation:(CLLocation*)location WithCompletion:(void(^)(NSDictionary *results))successBlock onError:(void(^)(NSError *error))errorBlock;
 - (void)getStateRepresentativesFromLocation:(CLLocation*)location WithCompletion:(void(^)(NSDictionary *results))successBlock onError:(void(^)(NSError *error))errorBlock;
-- (void)getStreetAddressFromSearchText:(NSString*)searchText withCompletion:(void(^)(NSArray *results))successBlock
-                               onError:(void(^)(NSError *error))errorBlock;
+- (void)getStreetAddressFromSearchText:(NSString*)searchText withCompletion:(void(^)(NSArray *results))successBlock onError:(void(^)(NSError *error))errorBlock;
+- (void)getRepContactFormsWithCompletion:(void(^)(NSDictionary *results))successBlock onError:(void(^)(NSError *error))errorBlock;
 @property (nonatomic, strong)AFHTTPRequestOperationManager *manager;
 @property (nonatomic, strong)UIImage *missingRepresentativePhoto;
 

--- a/Voices/RepsNetworkManager.m
+++ b/Voices/RepsNetworkManager.m
@@ -90,8 +90,7 @@
 
 #pragma mark - Get Street Address Method
 
-- (void)getStreetAddressFromSearchText:(NSString*)searchText withCompletion:(void(^)(NSArray *results))successBlock
-                               onError:(void(^)(NSError *error))errorBlock {
+- (void)getStreetAddressFromSearchText:(NSString*)searchText withCompletion:(void(^)(NSArray *results))successBlock onError:(void(^)(NSError *error))errorBlock {
     
     NSString *formattedString = [NSString stringWithFormat:@"https://maps.googleapis.com/maps/api/geocode/json?address=%@&key=%@", searchText, kGoogMaps];
     NSString *encodedURL = [formattedString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLFragmentAllowedCharacterSet]];
@@ -99,7 +98,9 @@
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
     
     AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
-    operation.responseSerializer = [AFJSONResponseSerializer serializer];
+    AFJSONResponseSerializer *serializer = [AFJSONResponseSerializer serializer];
+    [serializer setReadingOptions:NSJSONReadingAllowFragments];
+    operation.responseSerializer = serializer;
     
     [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         
@@ -117,6 +118,35 @@
     
     [operation start];
 }
+
+#pragma mark - Get Rep Contact Forms 
+
+- (void)getRepContactFormsWithCompletion:(void(^)(NSDictionary *results))successBlock
+                                 onError:(void(^)(NSError *error))errorBlock {
+    NSString *storageReference = @"https://firebasestorage.googleapis.com/v0/b/voices-430ae.appspot.com/o/repContactForms%20copy.json?alt=media&token=cf808323-a266-4ffc-a566-23497912b9f3";
+    NSURL *url = [NSURL URLWithString:storageReference];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    operation.responseSerializer = [AFJSONResponseSerializer serializer];
+    
+    [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+        
+        successBlock(responseObject);
+        
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Server Error" message:@"Please try again" preferredStyle:UIAlertControllerStyleAlert];
+        [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+        [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:alertController animated:YES completion:nil];
+        
+        NSLog(@"Error: %@", error);
+    }];
+    
+    [operation start];
+}
+
+
 
 
 @end

--- a/Voices/RepsViewController.m
+++ b/Voices/RepsViewController.m
@@ -65,7 +65,7 @@
     RepsCollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"RepsCollectionViewCell" forIndexPath:indexPath];
     
     cell.tableViewDataSource = [[RepsManager sharedInstance]fetchRepsForIndex:indexPath.item];
-    
+        
     cell.index = indexPath.item;
     cell.repDetailDelegate = self;
     [cell reloadTableView];


### PR DESCRIPTION
The branch is mistitled. The work for 372-repsContactForms is actually on the 342-SearchBarAddress branch. Sorry! 


The firebase method is in the RepsNetworkManager...

- (void)getRepContactFormsWithCompletion:(void(^)(NSDictionary *results))successBlock onError:(void(^)(NSError *error))errorBlock;

Called by the RepsManager ...

-(void)getRepContactFormsWithCompletion:(void (^)(void))successBlock onError:(void (^)(NSError *))errorBlock

(just realized these two methods have same titles, is that bad practice?)

This called in the AppDelegate right after 'unzipNYCDataSet'

-(void)getRepContactForms 

The RepsManager dictionary property holds the email addresses, and it's accessed in the RepTableViewCell init method when it's instantiated in the cellForAtIndexPath in RepsCollectionViewCell.

Finally the dictionary is accessed  in the emailButtonDidPress method in the RepTableViewCell.

Let me know what you think. Thank you.




