### PR TITLE
searchbar text reflects user's intention

### DIFF
--- a/Voices/RepsCollectionViewCell.m
+++ b/Voices/RepsCollectionViewCell.m
@@ -12,8 +12,6 @@
 #import "RepDetailViewController.h"
 #import "RepsManager.h"
 #import "LocationService.h"
-#import "SearchResultsManager.h"
-
 
 @interface RepsCollectionViewCell()
 

--- a/Voices/RepsCollectionViewCell.m
+++ b/Voices/RepsCollectionViewCell.m
@@ -12,6 +12,8 @@
 #import "RepDetailViewController.h"
 #import "RepsManager.h"
 #import "LocationService.h"
+#import "SearchResultsManager.h"
+
 
 @interface RepsCollectionViewCell()
 
@@ -106,6 +108,8 @@
 }
 
 - (void)pullToRefresh {
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"refreshSearchBarPullToRefresh" object:nil];     
     if([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedWhenInUse){
         [[LocationService sharedInstance]startUpdatingLocation];
         

--- a/Voices/RepsManager.h
+++ b/Voices/RepsManager.h
@@ -8,7 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
+
 @interface RepsManager : NSObject
+
 
 +(RepsManager *) sharedInstance;
 - (NSArray *)fetchRepsForIndex:(NSInteger)index;

--- a/Voices/RepsManager.m
+++ b/Voices/RepsManager.m
@@ -259,4 +259,5 @@
     return billDeBlasio;
 }
 
+
 @end

--- a/Voices/RootViewController.m
+++ b/Voices/RootViewController.m
@@ -209,8 +209,8 @@
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
     [textField resignFirstResponder];
     
-    [SearchResultsManager sharedInstance].searchMethod = textField.text;
-    self.searchTextField.text = [SearchResultsManager sharedInstance].searchMethod;
+    [SearchResultsManager sharedInstance].locationSearched = textField.text;
+    self.searchTextField.text = [SearchResultsManager sharedInstance].locationSearched;
     
     [[LocationService sharedInstance]getCoordinatesFromSearchText:textField.text withCompletion:^(CLLocation *locationResults) {
         
@@ -506,7 +506,7 @@
     
     self.searchResultsTableView.hidden = YES;
     self.darkView.hidden = YES;
-    self.searchTextField.text = [SearchResultsManager sharedInstance].searchMethod;
+    self.searchTextField.text = [SearchResultsManager sharedInstance].locationSearched;
     [self.searchTextField resignFirstResponder];
     [self.darkView removeGestureRecognizer:self.tap];
 }

--- a/Voices/RootViewController.m
+++ b/Voices/RootViewController.m
@@ -209,6 +209,9 @@
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
     [textField resignFirstResponder];
     
+    [SearchResultsManager sharedInstance].searchMethod = textField.text;
+    self.searchTextField.text = [SearchResultsManager sharedInstance].searchMethod;
+    
     [[LocationService sharedInstance]getCoordinatesFromSearchText:textField.text withCompletion:^(CLLocation *locationResults) {
         
         [[RepsManager sharedInstance]createFederalRepresentativesFromLocation:locationResults WithCompletion:^{
@@ -295,6 +298,7 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(presentPullToRefreshAlert) name:@"presentPullToRefreshAlert" object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(presentSearchViewController) name:@"presentSearchViewController" object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hideSearchResultsTableView) name:@"hideSearchResultsTableView" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refreshSearchText) name:@"refreshSearchBarPullToRefresh" object:nil];
 
 }
 
@@ -475,10 +479,9 @@
                               handler:^(UIAlertAction * action)
                               {
                                   [[LocationService sharedInstance]startUpdatingLocation];
-                                  [self refreshSearchText];
-                                  
-                                  
-                                  
+
+                                      [self refreshSearchText];
+ 
                               }];
     [alert addAction:button0];
     [alert addAction:button1];
@@ -503,10 +506,13 @@
     
     self.searchResultsTableView.hidden = YES;
     self.darkView.hidden = YES;
-    self.searchTextField.text = [SearchResultsManager sharedInstance].addressSearched;
+    if([SearchResultsManager sharedInstance].searchMethod != nil){
+        self.searchTextField.text = [SearchResultsManager sharedInstance].searchMethod;
+    }// TODO: searchbar value goes here //[SearchResultsManager sharedInstance].addressSearched;
     [self.searchTextField resignFirstResponder];
     [self.darkView removeGestureRecognizer:self.tap];
 }
+
 
 #pragma mark Call Center methods
 - (void)setupCallCenterToPresentThankYou {

--- a/Voices/RootViewController.m
+++ b/Voices/RootViewController.m
@@ -506,9 +506,7 @@
     
     self.searchResultsTableView.hidden = YES;
     self.darkView.hidden = YES;
-    if([SearchResultsManager sharedInstance].searchMethod != nil){
-        self.searchTextField.text = [SearchResultsManager sharedInstance].searchMethod;
-    }// TODO: searchbar value goes here //[SearchResultsManager sharedInstance].addressSearched;
+    self.searchTextField.text = [SearchResultsManager sharedInstance].searchMethod;
     [self.searchTextField resignFirstResponder];
     [self.darkView removeGestureRecognizer:self.tap];
 }

--- a/Voices/SearchResultsManager.h
+++ b/Voices/SearchResultsManager.h
@@ -8,14 +8,17 @@
 
 #import <UIKit/UIKit.h>
 
+
 @interface SearchResultsManager : NSObject <UITableViewDelegate, UITableViewDataSource>
 
+
+@property (nonatomic) NSString *searchMethod;
 @property (strong, nonatomic) NSArray *resultsArray;
 @property (strong, nonatomic) NSString *addressSearched;
 
 - (void)placeAutocomplete:(NSString *)searchText onSuccess:(void(^)(void))successBlock;
 - (void)clearSearchResults;
-
 + (SearchResultsManager *) sharedInstance;
+
 
 @end

--- a/Voices/SearchResultsManager.h
+++ b/Voices/SearchResultsManager.h
@@ -12,9 +12,8 @@
 @interface SearchResultsManager : NSObject <UITableViewDelegate, UITableViewDataSource>
 
 
-@property (nonatomic) NSString *searchMethod;
+@property (nonatomic) NSString *locationSearched;
 @property (strong, nonatomic) NSArray *resultsArray;
-@property (strong, nonatomic) NSString *addressSearched;
 
 - (void)placeAutocomplete:(NSString *)searchText onSuccess:(void(^)(void))successBlock;
 - (void)clearSearchResults;

--- a/Voices/SearchResultsManager.m
+++ b/Voices/SearchResultsManager.m
@@ -126,6 +126,7 @@
         
         [[LocationService sharedInstance]startUpdatingLocation];
         self.addressSearched = @"Current Location";
+        self.searchMethod = self.addressSearched;
         [[NSNotificationCenter defaultCenter]postNotificationName:@"hideSearchResultsTableView" object:nil];
     }
     else if (indexPath.row == 1) {
@@ -133,6 +134,7 @@
 
         if (homeAddress.length) {
             self.addressSearched = homeAddress;
+            self.searchMethod = self.addressSearched;
             [self fetchRepsForAddress:homeAddress];
         }
         else {
@@ -140,7 +142,9 @@
         }
     }
     else {
+        
         self.addressSearched = self.resultsArray[indexPath.row - 2];
+        self.searchMethod = self.addressSearched;
         [self fetchRepsForAddress:self.resultsArray[indexPath.row - 2]];
     }
 }
@@ -169,5 +173,9 @@
     }];
     [[NSNotificationCenter defaultCenter]postNotificationName:@"hideSearchResultsTableView" object:nil];
 }
+
+
+
+
 
 @end

--- a/Voices/SearchResultsManager.m
+++ b/Voices/SearchResultsManager.m
@@ -125,16 +125,16 @@
     if (indexPath.row == 0) {
         
         [[LocationService sharedInstance]startUpdatingLocation];
-        self.addressSearched = @"Current Location";
-        self.searchMethod = self.addressSearched;
+        self.locationSearched = @"Current Location";
+//        self.searchMethod = self.addressSearched;
         [[NSNotificationCenter defaultCenter]postNotificationName:@"hideSearchResultsTableView" object:nil];
     }
     else if (indexPath.row == 1) {
         NSString *homeAddress = [[NSUserDefaults standardUserDefaults]stringForKey:kHomeAddress];
 
         if (homeAddress.length) {
-            self.addressSearched = homeAddress;
-            self.searchMethod = self.addressSearched;
+            self.locationSearched = homeAddress;
+//            self.searchMethod = self.addressSearched;
             [self fetchRepsForAddress:homeAddress];
         }
         else {
@@ -143,8 +143,8 @@
     }
     else {
         
-        self.addressSearched = self.resultsArray[indexPath.row - 2];
-        self.searchMethod = self.addressSearched;
+        self.locationSearched = self.resultsArray[indexPath.row - 2];
+//        self.searchMethod = self.addressSearched;
         [self fetchRepsForAddress:self.resultsArray[indexPath.row - 2]];
     }
 }


### PR DESCRIPTION
By adding a string property called searchMethod to the SearchResultsManager, we have a storeable property which can be accessed when needed to change the searchbar text to reflect the user's intended mode of location discovery. 
When the user makes a pull-to-refresh gesture, the searchbar reflects this, reading, "Current Location". This was the trickiest one. To achieve setting the searchbar text at the right time, I fire off a notification from the RepsCollectionViewCell pullToRefresh method to the RootViewController refreshSearchText method. The other conditions were simpler to find the correct time to set, when the home addess or current location are selected,  the searchBar is set to reflect this. For user input addresses, the input text is retrieved, then set the searchMethod, and then accessed by the searchBar.