### PR TITLE
All actions are removed when group is unfollowed

### DIFF
--- a/Voices/FirebaseManager.m
+++ b/Voices/FirebaseManager.m
@@ -241,8 +241,10 @@
     // Remove associated actions
     NSMutableArray *discardedActions = [NSMutableArray array];
     for (Action *action in [CurrentUser sharedInstance].listOfActions) {
-        if ([action.groupKey isEqualToString:group.key]) {
-            [discardedActions addObject:action];
+        if(action.groupKey != nil && group.key != nil) {
+            if([action.groupKey caseInsensitiveCompare: group.key] == NSOrderedSame){
+                [discardedActions addObject:action];
+            }
         }
     }
     [[CurrentUser sharedInstance].listOfActions removeObjectsInArray:discardedActions];

--- a/Voices/TakeActionViewController.m
+++ b/Voices/TakeActionViewController.m
@@ -1,4 +1,4 @@
-//
+    //
 //  TakeActionViewController.m
 //  Voices
 //
@@ -61,7 +61,6 @@
     else {
         self.tableView.backgroundView.hidden = NO;
     }
-
     [self.tableView reloadData];
 }
 
@@ -271,7 +270,6 @@
     } else {
         [self userAuth];
     }
-
     [self.tableView reloadData];
 }
 


### PR DESCRIPTION
In the firebaseManager removeGroup method, actions are being removed from the list by comparison. The groupKeys coming from the database are not all case-uniform, resulting in some comparisons returning false and invalid actions being left in the list, consequently being reloaded into the tableview after a group had been unfollowed. I added a case-insensitive string compare to resolve this bug. 